### PR TITLE
#14: bug in ratio computing

### DIFF
--- a/src/main/java/org/terracotta/statistics/MappedOperationStatistic.java
+++ b/src/main/java/org/terracotta/statistics/MappedOperationStatistic.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.statistics;
+
+import org.terracotta.context.ContextManager;
+import org.terracotta.context.TreeNode;
+import org.terracotta.context.annotations.ContextAttribute;
+import org.terracotta.context.query.Matcher;
+import org.terracotta.context.query.Matchers;
+import org.terracotta.context.query.Query;
+import org.terracotta.statistics.observer.ChainedOperationObserver;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import static org.terracotta.context.query.Matchers.attributes;
+import static org.terracotta.context.query.Matchers.context;
+import static org.terracotta.context.query.Matchers.hasAttribute;
+import static org.terracotta.context.query.Matchers.identifier;
+import static org.terracotta.context.query.Matchers.subclassOf;
+import static org.terracotta.context.query.QueryBuilder.queryBuilder;
+
+@ContextAttribute("this")
+public class MappedOperationStatistic<S extends Enum<S>, D extends Enum<D>> implements OperationStatistic<D> {
+
+  @ContextAttribute("name") public final String name;
+  @ContextAttribute("tags") public final Set<String> tags;
+  @ContextAttribute("properties") public final Map<String, Object> properties;
+  @ContextAttribute("type") public final Class<D> outcomeType;
+
+  private final StatisticMapper<S, D> mapper;
+
+  public MappedOperationStatistic(Object tier, Map<D, Set<S>> translation, String statisticName, int tierHeight, String targetName, String discriminator) {
+
+    this.name = statisticName;
+    this.tags = Collections.singleton("tier");
+    this.properties = new HashMap<String, Object>();
+    this.properties.put("tierHeight", tierHeight);
+    this.properties.put("discriminator", discriminator);
+
+    Entry<D, Set<S>> first = translation.entrySet().iterator().next();
+    Class<S> outcomeType = first.getValue().iterator().next().getDeclaringClass();
+    this.outcomeType = first.getKey().getDeclaringClass();
+
+    this.mapper = new StatisticMapper<S, D>(translation, findOperationStat(tier, outcomeType, targetName));
+  }
+
+  @Override
+  public Class<D> type() {
+    return outcomeType;
+  }
+
+  @Override
+  public ValueStatistic<Long> statistic(D result) {
+    return mapper.statistic(result);
+  }
+
+  @Override
+  public ValueStatistic<Long> statistic(Set<D> results) {
+    return mapper.statistic(results);
+  }
+
+  @Override
+  public long count(D type) {
+    return mapper.count(type);
+  }
+
+  @Override
+  public long sum(Set<D> types) {
+    return mapper.sum(types);
+  }
+
+  @Override
+  public long sum() {
+    return mapper.sum();
+  }
+
+  @Override
+  public void addDerivedStatistic(final ChainedOperationObserver<? super D> derived) {
+    mapper.addDerivedStatistic(derived);
+  }
+
+  @Override
+  public void removeDerivedStatistic(ChainedOperationObserver<? super D> derived) {
+    mapper.removeDerivedStatistic(derived);
+  }
+
+  @Override
+  public void begin() {
+    mapper.begin();
+  }
+
+  @Override
+  public void end(D result) {
+    mapper.end(result);
+  }
+
+  @Override
+  public void end(D result, long... parameters) {
+    mapper.end(result, parameters);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <S extends Enum<S>> OperationStatistic<S> findOperationStat(Object rootNode, final Class<S> statisticType, final String statName) {
+    Query q = queryBuilder().descendants()
+            .filter(context(identifier(subclassOf(OperationStatistic.class))))
+            .filter(context(attributes(Matchers.<Map<String, Object>>allOf(
+                    hasAttribute("name", statName),
+                    hasAttribute("this", new Matcher<OperationStatistic>() {
+                      @Override
+                      protected boolean matchesSafely(OperationStatistic object) {
+                        return object.type().equals(statisticType);
+                      }
+                    })
+            )))).build();
+
+
+    Set<TreeNode> result = q.execute(Collections.singleton(ContextManager.nodeFor(rootNode)));
+
+    if (result.size() != 1) {
+      throw new RuntimeException("a single stat was expected; found " + result.size());
+    }
+
+    TreeNode node = result.iterator().next();
+    return (OperationStatistic<S>) node.getContext().attributes().get("this");
+  }
+
+}

--- a/src/main/java/org/terracotta/statistics/StatisticMapper.java
+++ b/src/main/java/org/terracotta/statistics/StatisticMapper.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.statistics;
+
+import org.terracotta.statistics.observer.ChainedOperationObserver;
+
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import static java.util.EnumSet.allOf;
+
+public class StatisticMapper<SOURCE extends Enum<SOURCE>, TARGET extends Enum<TARGET>> implements OperationStatistic<TARGET> {
+
+  private final Class<TARGET> targetType;
+  private final Class<SOURCE> sourceType;
+  private final OperationStatistic<SOURCE> statistic;
+  private final Map<TARGET, Set<SOURCE>> translation;
+  private final Map<SOURCE, TARGET> reverseTranslation;
+  private final ConcurrentMap<ChainedOperationObserver<? super TARGET>, ChainedOperationObserver<SOURCE>> derivedStats
+          = new ConcurrentHashMap<ChainedOperationObserver<? super TARGET>, ChainedOperationObserver<SOURCE>>();
+
+  public StatisticMapper(Map<TARGET, Set<SOURCE>> translation, OperationStatistic<SOURCE> statistic) {
+    Entry<TARGET, Set<SOURCE>> first = translation.entrySet().iterator().next();
+
+    this.targetType = first.getKey().getDeclaringClass();
+    this.sourceType = first.getValue().iterator().next().getDeclaringClass();
+    this.statistic = statistic;
+    this.translation = translation;
+    Set<TARGET> unmappedTierOutcomes = allOf(targetType);
+    unmappedTierOutcomes.removeAll(translation.keySet());
+    if (!unmappedTierOutcomes.isEmpty()) {
+      throw new IllegalArgumentException("Translation does not contain target outcomes " + unmappedTierOutcomes);
+    }
+
+    this.reverseTranslation = reverse(translation);
+    Set<SOURCE> unmappedStoreOutcomes = allOf(sourceType);
+    unmappedStoreOutcomes.removeAll(reverseTranslation.keySet());
+    if (!unmappedStoreOutcomes.isEmpty()) {
+      throw new IllegalArgumentException("Translation does not contain source outcomes " + unmappedStoreOutcomes);
+    }
+  }
+
+  private static <B extends Enum<B>, A extends Enum<A>> Map<B, A> reverse(Map<A, Set<B>> map) {
+    Map<B, A> reverse = Collections.emptyMap();
+
+    for (Entry<A, Set<B>> e : map.entrySet()) {
+      for (B b : e.getValue()) {
+        if (reverse.isEmpty()) {
+          reverse = new EnumMap<B, A>(b.getDeclaringClass());
+        }
+        if (reverse.put(b, e.getKey()) != null) {
+          throw new IllegalArgumentException("Reverse statistic outcome mapping is ill-defined: " + map);
+        }
+      }
+    }
+    return reverse;
+  }
+
+  @Override
+  public Class<TARGET> type() {
+    return targetType;
+  }
+
+  @Override
+  public ValueStatistic<Long> statistic(TARGET result) {
+    return statistic.statistic(translation.get(result));
+  }
+
+  @Override
+  public ValueStatistic<Long> statistic(Set<TARGET> results) {
+    Set<SOURCE> translated = EnumSet.noneOf(sourceType);
+    for (TARGET result : results) {
+      translated.addAll(translation.get(result));
+    }
+    return statistic.statistic(translated);
+  }
+
+  @Override
+  public long count(TARGET type) {
+    return statistic.sum(translation.get(type));
+  }
+
+  @Override
+  public long sum(Set<TARGET> types) {
+    Set<SOURCE> translated = EnumSet.noneOf(sourceType);
+    for (TARGET type : types) {
+      translated.addAll(translation.get(type));
+    }
+    return statistic.sum(translated);
+  }
+
+  @Override
+  public long sum() {
+    return statistic.sum();
+  }
+
+  @Override
+  public void addDerivedStatistic(final ChainedOperationObserver<? super TARGET> derived) {
+    ChainedOperationObserver<SOURCE> translator = new ChainedOperationObserver<SOURCE>() {
+      @Override
+      public void begin(long time) {
+        derived.begin(time);
+      }
+
+      @Override
+      public void end(long time, SOURCE result) {
+        derived.end(time, reverseTranslation.get(result));
+      }
+
+      @Override
+      public void end(long time, SOURCE result, long... parameters) {
+        derived.end(time, reverseTranslation.get(result), parameters);
+      }
+    };
+    if (derivedStats.putIfAbsent(derived, translator) == null) {
+      statistic.addDerivedStatistic(translator);
+    }
+  }
+
+  @Override
+  public void removeDerivedStatistic(ChainedOperationObserver<? super TARGET> derived) {
+    ChainedOperationObserver<SOURCE> translator = derivedStats.remove(derived);
+    if (translator != null) {
+      statistic.removeDerivedStatistic(translator);
+    }
+  }
+
+  @Override
+  public void begin() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void end(TARGET result) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void end(TARGET result, long... parameters) {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/src/test/java/org/terracotta/statistics/ratio/Cache.java
+++ b/src/test/java/org/terracotta/statistics/ratio/Cache.java
@@ -1,0 +1,76 @@
+/*
+ * All content copyright Terracotta, Inc., unless otherwise indicated.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.statistics.ratio;
+
+import org.terracotta.statistics.MappedOperationStatistic;
+import org.terracotta.statistics.StatisticsManager;
+import org.terracotta.statistics.observer.OperationObserver;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.terracotta.statistics.StatisticBuilder.operation;
+
+/**
+ * @author Mathieu Carbou
+ */
+class Cache {
+
+  OperationObserver<StoreOperationOutcomes.GetOutcome> getObserver;
+  Map<String, String> data = new ConcurrentHashMap<String, String>() {
+    @Override
+    public String get(Object key) {
+      // costly operation
+      try {
+        Thread.sleep(50);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+      return super.get(key);
+    }
+  };
+
+  Cache() {
+    getObserver = operation(StoreOperationOutcomes.GetOutcome.class).named("get").of(this).tag("OnHeap").build();
+
+    MappedOperationStatistic<StoreOperationOutcomes.GetOutcome, TierOperationOutcomes.GetOutcome> get =
+        new MappedOperationStatistic<StoreOperationOutcomes.GetOutcome, TierOperationOutcomes.GetOutcome>(
+            this,
+            TierOperationOutcomes.GET_TRANSLATION,
+            "get",
+            10000,
+            "get",
+            "OnHeap");
+
+    StatisticsManager.associate(get).withParent(this);
+  }
+
+  String put(String key, String value) {
+    return data.put(key, value);
+  }
+
+  String get(String k) {
+    getObserver.begin();
+    String v = data.get(k);
+    if (v == null) {
+      getObserver.end(StoreOperationOutcomes.GetOutcome.MISS);
+    } else {
+      getObserver.end(StoreOperationOutcomes.GetOutcome.HIT);
+    }
+    return v;
+  }
+
+}

--- a/src/test/java/org/terracotta/statistics/ratio/RatioTest.java
+++ b/src/test/java/org/terracotta/statistics/ratio/RatioTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.statistics.ratio;
+
+import org.junit.After;
+import org.junit.Test;
+import org.terracotta.context.extended.OperationStatisticDescriptor;
+import org.terracotta.context.extended.RegisteredCompoundStatistic;
+import org.terracotta.context.extended.RegisteredRatioStatistic;
+import org.terracotta.context.extended.RegisteredStatistic;
+import org.terracotta.context.extended.StatisticsRegistry;
+import org.terracotta.statistics.archive.Timestamped;
+import org.terracotta.statistics.extended.CompoundOperation;
+import org.terracotta.statistics.extended.SampledStatistic;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.Collections.singleton;
+import static java.util.EnumSet.allOf;
+import static java.util.EnumSet.of;
+
+/**
+ * @author Mathieu Carbou
+ */
+public class RatioTest {
+
+  ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+
+  Cache cache = new Cache();
+
+  StatisticsRegistry statisticsRegistry = new StatisticsRegistry(
+      cache,
+      executor,
+      1, TimeUnit.MINUTES, // window
+      100, // history size
+      1, TimeUnit.SECONDS, // sampling frequency
+      10, TimeUnit.MINUTES); // TTD
+
+  @After
+  public void tearDown() throws Exception {
+    statisticsRegistry.clearRegistrations();
+    executor.shutdown();
+  }
+
+  @Test(timeout = 10000)
+  public void test_ratio_calculated() throws Exception {
+    OperationStatisticDescriptor getTierStatisticDescriptor = OperationStatisticDescriptor.descriptor("get", singleton("tier"), TierOperationOutcomes.GetOutcome.class);
+    statisticsRegistry.registerCompoundOperations("Hit", getTierStatisticDescriptor, of(TierOperationOutcomes.GetOutcome.HIT));
+    statisticsRegistry.registerCompoundOperations("Miss", getTierStatisticDescriptor, of(TierOperationOutcomes.GetOutcome.MISS));
+    statisticsRegistry.registerRatios("HitRatio", getTierStatisticDescriptor,
+        of(org.terracotta.statistics.ratio.TierOperationOutcomes.GetOutcome.HIT),
+        allOf(TierOperationOutcomes.GetOutcome.class));
+
+    // trigger computation
+    List<? extends Timestamped<? extends Number>> list = queryStatistic("OnHeap:HitRatio");
+    System.out.println("triggered task scheduling: " + list.size() + " samples");
+
+    // When testing ratios, we need to wait for the first computation (we do not have any choice) to happen because ratio depends on 2 other sampled statistics.
+    // If you do not wait, then you'll always get some NaN because the hits will be done within the 1st second, and the hits won't be done in the right "window".
+    // A ratio is computed by dividing a rate with another rate. See CompoundOperationImpl.ratioOf().
+    // And a rate is computed with values aggregated into a EventRateSimpleMovingAverage.
+    // The call to EventRateSimpleMovingAverage.rateUsingSeconds() will return 0 during the fist second (until first computation did happen).
+    // So the hits must be after the first second so that values get accumulated into the partitions of EventRateSimpleMovingAverage.
+    Thread.sleep(2000);
+
+    System.out.println("3 puts");
+    cache.put("1", "1");
+    cache.put("2", "2");
+    cache.put("3", "3");
+
+    System.out.println("3 hits");
+    cache.get("1"); // hit
+    cache.get("2"); // hit
+    cache.get("3"); // hit
+
+    do {
+      list = queryStatistic("OnHeap:HitRatio");
+      System.out.println(list.size() + " samples");
+      for (Timestamped<? extends Number> timestamped : list) {
+        System.out.println(timestamped.getTimestamp() + " - " + timestamped.getSample());
+      }
+      try {
+        Thread.sleep(1000);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    } while (!Thread.currentThread().isInterrupted() && (list.isEmpty() || !list.get(list.size() - 1).getSample().equals(1d)));
+  }
+
+  public List<? extends Timestamped<? extends Number>> queryStatistic(String statisticName) {
+    Map<String, RegisteredStatistic> registrations = statisticsRegistry.getRegistrations();
+    for (Map.Entry<String, RegisteredStatistic> entry : registrations.entrySet()) {
+      String name = entry.getKey();
+      RegisteredStatistic registeredStatistic = entry.getValue();
+
+      if (registeredStatistic instanceof RegisteredCompoundStatistic) {
+        RegisteredCompoundStatistic registeredCompoundStatistic = (RegisteredCompoundStatistic) registeredStatistic;
+        CompoundOperation<?> compoundOperation = registeredCompoundStatistic.getCompoundOperation();
+
+        if ((name + "Count").equals(statisticName)) {
+          SampledStatistic<Long> count = compoundOperation.compound((Set) registeredCompoundStatistic.getCompound()).count();
+          return count.history();
+        }
+
+      } else if (registeredStatistic instanceof RegisteredRatioStatistic) {
+        if (name.equals(statisticName)) {
+          RegisteredRatioStatistic registeredRatioStatistic = (RegisteredRatioStatistic) registeredStatistic;
+          CompoundOperation<?> compoundOperation = registeredRatioStatistic.getCompoundOperation();
+          SampledStatistic<Double> ratio = (SampledStatistic) compoundOperation.ratioOf(
+              (Set) registeredRatioStatistic.getNumerator(),
+              (Set) registeredRatioStatistic.getDenominator());
+          return ratio.history();
+        }
+
+      } else {
+        throw new UnsupportedOperationException("Cannot handle registered statistic type : " + registeredStatistic);
+      }
+    }
+
+    throw new IllegalArgumentException("No registered statistic named '" + statisticName + "'");
+  }
+
+}

--- a/src/test/java/org/terracotta/statistics/ratio/StoreOperationOutcomes.java
+++ b/src/test/java/org/terracotta/statistics/ratio/StoreOperationOutcomes.java
@@ -1,0 +1,33 @@
+/*
+ * All content copyright Terracotta, Inc., unless otherwise indicated.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.statistics.ratio;
+
+/**
+ * @author Mathieu Carbou
+ */
+interface StoreOperationOutcomes {
+
+  enum GetOutcome implements StoreOperationOutcomes {
+    /**
+     * hit
+     */
+    HIT,
+    /**
+     * miss
+     */
+    MISS,
+  }
+}

--- a/src/test/java/org/terracotta/statistics/ratio/TierOperationOutcomes.java
+++ b/src/test/java/org/terracotta/statistics/ratio/TierOperationOutcomes.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.statistics.ratio;
+
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.Collections.unmodifiableMap;
+import static java.util.EnumSet.of;
+
+/**
+ * @author Mathieu Carbou
+ */
+class TierOperationOutcomes {
+
+  static final Map<GetOutcome, Set<StoreOperationOutcomes.GetOutcome>> GET_TRANSLATION;
+
+  static {
+    Map<GetOutcome, Set<StoreOperationOutcomes.GetOutcome>> translation = new EnumMap<GetOutcome, Set<StoreOperationOutcomes.GetOutcome>>(GetOutcome.class);
+    translation.put(GetOutcome.HIT, of(StoreOperationOutcomes.GetOutcome.HIT));
+    translation.put(GetOutcome.MISS, of(StoreOperationOutcomes.GetOutcome.MISS));
+    GET_TRANSLATION = unmodifiableMap(translation);
+  }
+
+  enum GetOutcome {
+    HIT,
+    MISS,
+  }
+
+}


### PR DESCRIPTION
In this PR, I added a test to reproduce the issue we have in this Ehcache PR:

ehcache/ehcache3#1579

Ratio computation does not work, except if we wait for a certain amount of time before doing the cache.get operations.

`RatioTest` is failing. But if you uncomment `//Thread.sleep(2000);`, it will pass.

@chrisdennis @lorban : I think I'll need your help to troubleshoot that...

Thanks!