### PR TITLE
#16: Several stat framework improvements / fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.terracotta</groupId>
   <artifactId>statistics</artifactId>
-  <version>1.2-SNAPSHOT</version>
+  <version>1.4-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Terracotta Statistics</name>

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,12 @@
       <version>3.6</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>1.9.5</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/org/terracotta/context/extended/OperationStatisticDescriptor.java
+++ b/src/main/java/org/terracotta/context/extended/OperationStatisticDescriptor.java
@@ -20,13 +20,13 @@ import java.util.Set;
 /**
  * @author Ludovic Orban
  */
-public final class OperationStatisticDescriptor {
+public final class OperationStatisticDescriptor<T extends Enum<T>> {
 
   private final String observerName;
   private final Set<String> tags;
-  private final Class<? extends Enum<?>> type;
+  private final Class<T> type;
 
-  private OperationStatisticDescriptor(String observerName, Set<String> tags, Class<? extends Enum<?>> type) {
+  private OperationStatisticDescriptor(String observerName, Set<String> tags, Class<T> type) {
     this.observerName = observerName;
     this.tags = tags;
     this.type = type;
@@ -40,12 +40,12 @@ public final class OperationStatisticDescriptor {
     return tags;
   }
 
-  public Class<? extends Enum<?>> getType() {
+  public Class<T> getType() {
     return type;
   }
 
-  public static OperationStatisticDescriptor descriptor(String observerName, Set<String> tags, Class<? extends Enum<?>> type) {
-    return new OperationStatisticDescriptor(observerName, tags, type);
+  public static <T extends Enum<T>> OperationStatisticDescriptor<T> descriptor(String observerName, Set<String> tags, Class<T> type) {
+    return new OperationStatisticDescriptor<T>(observerName, tags, type);
   }
 
 }

--- a/src/main/java/org/terracotta/context/extended/RegisteredCompoundOperationStatistic.java
+++ b/src/main/java/org/terracotta/context/extended/RegisteredCompoundOperationStatistic.java
@@ -21,15 +21,15 @@ import org.terracotta.statistics.extended.SamplingSupport;
 /**
  * @author Ludovic Orban
  */
-public abstract class RegisteredCompoundOperationStatistic extends RegisteredStatistic {
+public abstract class RegisteredCompoundOperationStatistic<T extends Enum<T>> implements RegisteredStatistic {
 
-  private final CompoundOperation<?> compoundOperation;
+  private final CompoundOperation<T> compoundOperation;
 
-  public RegisteredCompoundOperationStatistic(CompoundOperation<?> compoundOperation) {
+  public RegisteredCompoundOperationStatistic(CompoundOperation<T> compoundOperation) {
     this.compoundOperation = compoundOperation;
   }
 
-  public CompoundOperation<?> getCompoundOperation() {
+  public CompoundOperation<T> getCompoundOperation() {
     return compoundOperation;
   }
 

--- a/src/main/java/org/terracotta/context/extended/RegisteredCompoundStatistic.java
+++ b/src/main/java/org/terracotta/context/extended/RegisteredCompoundStatistic.java
@@ -16,21 +16,31 @@
 package org.terracotta.context.extended;
 
 import org.terracotta.statistics.extended.CompoundOperation;
+import org.terracotta.statistics.extended.Result;
 
 import java.util.EnumSet;
 
 /**
  * @author Ludovic Orban
  */
-public class RegisteredCompoundStatistic extends RegisteredCompoundOperationStatistic {
-  private final EnumSet<?> compound;
+public class RegisteredCompoundStatistic<T extends Enum<T>> extends RegisteredCompoundOperationStatistic<T> {
+  private final EnumSet<T> compound;
 
-  public RegisteredCompoundStatistic(CompoundOperation<?> compoundOperation, EnumSet<?> compound) {
+  public RegisteredCompoundStatistic(CompoundOperation<T> compoundOperation, EnumSet<T> compound) {
     super(compoundOperation);
     this.compound = compound;
   }
 
-  public EnumSet<?> getCompound() {
+  @Override
+  public RegistrationType getType() {
+    return RegistrationType.COMPOUND;
+  }
+
+  public EnumSet<T> getCompound() {
     return compound;
+  }
+
+  public Result getResult() {
+    return getCompoundOperation().compound(getCompound());
   }
 }

--- a/src/main/java/org/terracotta/context/extended/RegisteredCounterStatistic.java
+++ b/src/main/java/org/terracotta/context/extended/RegisteredCounterStatistic.java
@@ -16,20 +16,26 @@
 package org.terracotta.context.extended;
 
 import org.terracotta.statistics.extended.ExpiringSampledStatistic;
+import org.terracotta.statistics.extended.SampledStatistic;
 import org.terracotta.statistics.extended.SamplingSupport;
 
 /**
  * Class used to register counter statistics (MappingCount, etc.)
  */
-public class RegisteredCounterStatistic extends RegisteredStatistic {
+public class RegisteredCounterStatistic implements RegisteredStatistic {
 
-  private final ExpiringSampledStatistic<?> sampledStatistic;
+  private final ExpiringSampledStatistic<Long> sampledStatistic;
 
-  public RegisteredCounterStatistic(ExpiringSampledStatistic<?> sampledStatistic) {
+  public RegisteredCounterStatistic(ExpiringSampledStatistic<Long> sampledStatistic) {
     this.sampledStatistic = sampledStatistic;
   }
 
-  public ExpiringSampledStatistic<?> getSampledStatistic() {
+  @Override
+  public RegistrationType getType() {
+    return RegistrationType.COUNTER;
+  }
+
+  public SampledStatistic<Long> getSampledStatistic() {
     return sampledStatistic;
   }
 

--- a/src/main/java/org/terracotta/context/extended/RegisteredRatioStatistic.java
+++ b/src/main/java/org/terracotta/context/extended/RegisteredRatioStatistic.java
@@ -16,27 +16,38 @@
 package org.terracotta.context.extended;
 
 import org.terracotta.statistics.extended.CompoundOperation;
+import org.terracotta.statistics.extended.SampledStatistic;
 
 import java.util.EnumSet;
 
 /**
  * @author Ludovic Orban
  */
-public class RegisteredRatioStatistic extends RegisteredCompoundOperationStatistic {
-  private final EnumSet<?> numerator;
-  private final EnumSet<?> denominator;
+public class RegisteredRatioStatistic<T extends Enum<T>> extends RegisteredCompoundOperationStatistic<T> {
+  private final EnumSet<T> numerator;
+  private final EnumSet<T> denominator;
 
-  public RegisteredRatioStatistic(CompoundOperation<?> compoundOperation, EnumSet<?> numerator, EnumSet<?> denominator) {
+  public RegisteredRatioStatistic(CompoundOperation<T> compoundOperation, EnumSet<T> numerator, EnumSet<T> denominator) {
     super(compoundOperation);
     this.numerator = numerator;
     this.denominator = denominator;
   }
 
-  public EnumSet<?> getNumerator() {
+  @Override
+  public RegistrationType getType() {
+    return RegistrationType.RATIO;
+  }
+
+  public EnumSet<T> getNumerator() {
     return numerator;
   }
 
-  public EnumSet<?> getDenominator() {
+  public EnumSet<T> getDenominator() {
     return denominator;
+  }
+
+  public SampledStatistic<Double> getSampledStatistic() {
+    CompoundOperation<T> operation = getCompoundOperation();
+    return operation.ratioOf(getNumerator(), getDenominator());
   }
 }

--- a/src/main/java/org/terracotta/context/extended/RegisteredSizeStatistic.java
+++ b/src/main/java/org/terracotta/context/extended/RegisteredSizeStatistic.java
@@ -16,20 +16,26 @@
 package org.terracotta.context.extended;
 
 import org.terracotta.statistics.extended.ExpiringSampledStatistic;
+import org.terracotta.statistics.extended.SampledStatistic;
 import org.terracotta.statistics.extended.SamplingSupport;
 
 /**
  * Class used to register size statistics (BytesSize, etc.)
  */
-public class RegisteredSizeStatistic extends RegisteredStatistic {
+public class RegisteredSizeStatistic implements RegisteredStatistic {
 
-  private final ExpiringSampledStatistic<?> sampledStatistic;
+  private final ExpiringSampledStatistic<Long> sampledStatistic;
 
-  public RegisteredSizeStatistic(ExpiringSampledStatistic<?> sampledStatistic) {
+  public RegisteredSizeStatistic(ExpiringSampledStatistic<Long> sampledStatistic) {
     this.sampledStatistic = sampledStatistic;
   }
 
-  public ExpiringSampledStatistic<?> getSampledStatistic() {
+  @Override
+  public RegistrationType getType() {
+    return RegistrationType.SIZE;
+  }
+
+  public SampledStatistic<Long> getSampledStatistic() {
     return sampledStatistic;
   }
 

--- a/src/main/java/org/terracotta/context/extended/RegisteredStatistic.java
+++ b/src/main/java/org/terracotta/context/extended/RegisteredStatistic.java
@@ -20,8 +20,10 @@ import org.terracotta.statistics.extended.SamplingSupport;
 /**
  * @author Ludovic Orban
  */
-public abstract class RegisteredStatistic {
+public interface RegisteredStatistic {
 
-  public abstract SamplingSupport getSupport();
+  SamplingSupport getSupport();
+
+  RegistrationType getType();
 
 }

--- a/src/main/java/org/terracotta/context/extended/RegistrationType.java
+++ b/src/main/java/org/terracotta/context/extended/RegistrationType.java
@@ -13,44 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terracotta.statistics.extended;
-
-import org.terracotta.statistics.archive.Timestamped;
-
-import java.util.List;
+package org.terracotta.context.extended;
 
 /**
- * @author Ludovic Orban
+ * @author Mathieu Carbou
  */
-public interface SampledStatistic<T extends Number> {
-
-  /**
-   * Active.
-   *
-   * @return true, if successful
-   */
-  boolean active();
-
-  /**
-   * Value.
-   *
-   * @return the t
-   */
-  T value();
-
-  /**
-   * History.
-   *
-   * @return the list
-   */
-  List<Timestamped<T>> history();
-
-  /**
-   * History, from a given time in ms
-   *
-   * @return the list
-   */
-  List<Timestamped<T>> history(long since);
-
-  SampleType type();
+public enum RegistrationType {
+  COMPOUND,
+  RATIO,
+  SIZE,
+  COUNTER
 }

--- a/src/main/java/org/terracotta/statistics/StatisticsManager.java
+++ b/src/main/java/org/terracotta/statistics/StatisticsManager.java
@@ -42,7 +42,7 @@ public class StatisticsManager extends ContextManager {
       }
     });
   }
-  
+
   public static <T extends Enum<T>> OperationObserver<T> createOperationStatistic(Object context, String name, Set<String> tags, Class<T> eventTypes) {
     return createOperationStatistic(context, name, tags, Collections.<String, Object>emptyMap(), eventTypes);
   }

--- a/src/main/java/org/terracotta/statistics/extended/AbstractSampledStatistic.java
+++ b/src/main/java/org/terracotta/statistics/extended/AbstractSampledStatistic.java
@@ -39,17 +39,19 @@ abstract class AbstractSampledStatistic<T extends Number> implements SampledStat
    * The history.
    */
   private final StatisticHistory<T> history;
+  private final SampleType type;
 
   /**
    * Instantiates a new abstract statistic.
-   *
-   * @param executor        the executor
+   *  @param executor        the executor
    * @param historySize     the history size
    * @param historyPeriod   the history period
    * @param historyTimeUnit the history time unit
+   * @param type
    */
-  AbstractSampledStatistic(ValueStatistic<T> source, ScheduledExecutorService executor, int historySize, long historyPeriod, TimeUnit historyTimeUnit) {
+  AbstractSampledStatistic(ValueStatistic<T> source, ScheduledExecutorService executor, int historySize, long historyPeriod, TimeUnit historyTimeUnit, SampleType type) {
     this.source = source;
+    this.type = type;
     this.history = new StatisticHistory<T>(source, executor, historySize, historyPeriod, historyTimeUnit);
   }
 
@@ -67,6 +69,16 @@ abstract class AbstractSampledStatistic<T extends Number> implements SampledStat
   @Override
   public List<Timestamped<T>> history() {
     return history.history();
+  }
+
+  @Override
+  public List<Timestamped<T>> history(long since) {
+    return history.history(since);
+  }
+
+  @Override
+  public SampleType type() {
+    return type;
   }
 
   /**

--- a/src/main/java/org/terracotta/statistics/extended/CompoundOperation.java
+++ b/src/main/java/org/terracotta/statistics/extended/CompoundOperation.java
@@ -15,8 +15,7 @@
  */
 package org.terracotta.statistics.extended;
 
-import java.util.Map;
-import java.util.Set;
+import java.util.EnumSet;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -47,7 +46,7 @@ public interface CompoundOperation<T extends Enum<T>> extends SamplingSupport {
    * @param results the results
    * @return the result
    */
-  Result compound(Set<T> results);
+  Result compound(EnumSet<T> results);
 
   /**
    * Count operation.
@@ -60,10 +59,10 @@ public interface CompoundOperation<T extends Enum<T>> extends SamplingSupport {
    * Ratio of.
    *
    * @param numerator  the numerator
-   * @param denomiator the denomiator
+   * @param denominator the denomiator
    * @return the statistic
    */
-  SampledStatistic<Double> ratioOf(Set<T> numerator, Set<T> denomiator);
+  SampledStatistic<Double> ratioOf(EnumSet<T> numerator, EnumSet<T> denominator);
 
   /**
    * Sets the always on.

--- a/src/main/java/org/terracotta/statistics/extended/CompoundOperationImpl.java
+++ b/src/main/java/org/terracotta/statistics/extended/CompoundOperationImpl.java
@@ -96,7 +96,7 @@ public class CompoundOperationImpl<T extends Enum<T>> implements CompoundOperati
   }
 
   @Override
-  public Result compound(Set<T> results) {
+  public Result compound(EnumSet<T> results) {
     if (results.size() == 1) {
       return component(results.iterator().next());
     } else {
@@ -122,7 +122,7 @@ public class CompoundOperationImpl<T extends Enum<T>> implements CompoundOperati
   }
 
   @Override
-  public SampledStatistic<Double> ratioOf(Set<T> numerator, Set<T> denominator) {
+  public SampledStatistic<Double> ratioOf(EnumSet<T> numerator, EnumSet<T> denominator) {
     @SuppressWarnings("unchecked")
     List<Set<T>> key = Arrays.<Set<T>>asList(EnumSet.copyOf(numerator), EnumSet.copyOf(denominator));
 
@@ -135,7 +135,7 @@ public class CompoundOperationImpl<T extends Enum<T>> implements CompoundOperati
         public Double value() {
           return numeratorRate.value() / denominatorRate.value();
         }
-      }, executor, historySize, historyPeriod, historyTimeUnit);
+      }, executor, historySize, historyPeriod, historyTimeUnit, SampleType.RATIO);
       ExpiringSampledStatistic<Double> racer = ratios.putIfAbsent(key, created);
       if (racer == null) {
         return created;

--- a/src/main/java/org/terracotta/statistics/extended/ExpiringSampledStatistic.java
+++ b/src/main/java/org/terracotta/statistics/extended/ExpiringSampledStatistic.java
@@ -36,8 +36,8 @@ public class ExpiringSampledStatistic<T extends Number> extends SemiExpiringSamp
    * @param historySize   size of sample history
    * @param historyPeriod period between samples
    */
-  public ExpiringSampledStatistic(ValueStatistic<T> source, ScheduledExecutorService executor, int historySize, long historyPeriod, TimeUnit historyTimeUnit) {
-    super(source, executor, historySize, historyPeriod, historyTimeUnit);
+  public ExpiringSampledStatistic(ValueStatistic<T> source, ScheduledExecutorService executor, int historySize, long historyPeriod, TimeUnit historyTimeUnit, SampleType type) {
+    super(source, executor, historySize, historyPeriod, historyTimeUnit, type);
   }
 
   @Override

--- a/src/main/java/org/terracotta/statistics/extended/LatencyImpl.java
+++ b/src/main/java/org/terracotta/statistics/extended/LatencyImpl.java
@@ -58,9 +58,9 @@ class LatencyImpl<T extends Enum<T>> implements Latency {
   public LatencyImpl(OperationStatistic<T> statistic, Set<T> targets, long averagePeriod, TimeUnit averageTimeUnit,
                      ScheduledExecutorService executor, int historySize, long historyPeriod, TimeUnit historyTimeUnit) {
     this.average = new EventParameterSimpleMovingAverage(averagePeriod, averageTimeUnit);
-    this.minimumStatistic = new SampledStatisticImpl<Long>(this, average.minimumStatistic(), executor, historySize, historyPeriod, historyTimeUnit);
-    this.maximumStatistic = new SampledStatisticImpl<Long>(this, average.maximumStatistic(), executor, historySize, historyPeriod, historyTimeUnit);
-    this.averageStatistic = new SampledStatisticImpl<Double>(this, average.averageStatistic(), executor, historySize, historyPeriod, historyTimeUnit);
+    this.minimumStatistic = new SampledStatisticImpl<Long>(this, average.minimumStatistic(), executor, historySize, historyPeriod, historyTimeUnit, SampleType.LATENCY_MIN);
+    this.maximumStatistic = new SampledStatisticImpl<Long>(this, average.maximumStatistic(), executor, historySize, historyPeriod, historyTimeUnit, SampleType.LATENCY_MAX);
+    this.averageStatistic = new SampledStatisticImpl<Double>(this, average.averageStatistic(), executor, historySize, historyPeriod, historyTimeUnit, SampleType.LATENCY_AVG);
     this.latencySampler = new LatencySampling<T>(targets, 1.0);
     this.latencySampler.addDerivedStatistic(average);
     this.source = statistic;

--- a/src/main/java/org/terracotta/statistics/extended/RateImpl.java
+++ b/src/main/java/org/terracotta/statistics/extended/RateImpl.java
@@ -56,7 +56,7 @@ public class RateImpl<T extends Enum<T>> implements SampledStatistic<Double> {
   public RateImpl(final OperationStatistic<T> source, final Set<T> targets, long averagePeriod, TimeUnit averageTimeUnit,
                   ScheduledExecutorService executor, int historySize, long historyPeriod, TimeUnit historyTimeUnit) {
     this.rate = new EventRateSimpleMovingAverage(averagePeriod, averageTimeUnit);
-    this.delegate = new ExpiringSampledStatistic<Double>(rate, executor, historySize, historyPeriod, historyTimeUnit) {
+    this.delegate = new ExpiringSampledStatistic<Double>(rate, executor, historySize, historyPeriod, historyTimeUnit, SampleType.RATE) {
 
       private final ChainedOperationObserver<T> observer = new OperationResultFilter<T>(targets, rate);
 
@@ -87,6 +87,16 @@ public class RateImpl<T extends Enum<T>> implements SampledStatistic<Double> {
   @Override
   public List<Timestamped<Double>> history() {
     return delegate.history();
+  }
+
+  @Override
+  public List<Timestamped<Double>> history(long since) {
+    return delegate.history(since);
+  }
+
+  @Override
+  public SampleType type() {
+    return SampleType.RATE;
   }
 
   /**

--- a/src/main/java/org/terracotta/statistics/extended/ResultImpl.java
+++ b/src/main/java/org/terracotta/statistics/extended/ResultImpl.java
@@ -56,7 +56,7 @@ class ResultImpl<T extends Enum<T>> implements Result {
    */
   public ResultImpl(OperationStatistic<T> source, Set<T> targets, long averagePeriod, TimeUnit averageTimeUnit,
                     ScheduledExecutorService executor, int historySize, long historyPeriod, TimeUnit historyTimeUnit) {
-    this.count = new SemiExpiringSampledStatistic<Long>(source.statistic(targets), executor, historySize, historyPeriod, historyTimeUnit);
+    this.count = new SemiExpiringSampledStatistic<Long>(source.statistic(targets), executor, historySize, historyPeriod, historyTimeUnit, SampleType.COUNTER);
     this.latency = new LatencyImpl<T>(source, targets, averagePeriod, averageTimeUnit, executor, historySize, historyPeriod, historyTimeUnit);
     this.rate = new RateImpl<T>(source, targets, averagePeriod, averageTimeUnit, executor, historySize, historyPeriod, historyTimeUnit);
   }

--- a/src/main/java/org/terracotta/statistics/extended/SampleType.java
+++ b/src/main/java/org/terracotta/statistics/extended/SampleType.java
@@ -15,42 +15,17 @@
  */
 package org.terracotta.statistics.extended;
 
-import org.terracotta.statistics.archive.Timestamped;
-
-import java.util.List;
-
 /**
- * @author Ludovic Orban
+ * @author Mathieu Carbou
  */
-public interface SampledStatistic<T extends Number> {
+public enum SampleType {
 
-  /**
-   * Active.
-   *
-   * @return true, if successful
-   */
-  boolean active();
+  COUNTER,
+  RATE,
+  LATENCY_MIN,
+  LATENCY_MAX,
+  LATENCY_AVG,
+  RATIO,
+  SIZE
 
-  /**
-   * Value.
-   *
-   * @return the t
-   */
-  T value();
-
-  /**
-   * History.
-   *
-   * @return the list
-   */
-  List<Timestamped<T>> history();
-
-  /**
-   * History, from a given time in ms
-   *
-   * @return the list
-   */
-  List<Timestamped<T>> history(long since);
-
-  SampleType type();
 }

--- a/src/main/java/org/terracotta/statistics/extended/SampledStatisticImpl.java
+++ b/src/main/java/org/terracotta/statistics/extended/SampledStatisticImpl.java
@@ -38,8 +38,8 @@ class SampledStatisticImpl<T extends Number> extends AbstractSampledStatistic<T>
    * @param historyPeriod   the history period
    * @param historyTimeUnit the history time unit
    */
-  public SampledStatisticImpl(LatencyImpl latency, ValueStatistic<T> value, ScheduledExecutorService executor, int historySize, long historyPeriod, TimeUnit historyTimeUnit) {
-    super(value, executor, historySize, historyPeriod, historyTimeUnit);
+  public SampledStatisticImpl(LatencyImpl latency, ValueStatistic<T> value, ScheduledExecutorService executor, int historySize, long historyPeriod, TimeUnit historyTimeUnit, SampleType type) {
+    super(value, executor, historySize, historyPeriod, historyTimeUnit, type);
     this.latency = latency;
   }
 
@@ -58,5 +58,11 @@ class SampledStatisticImpl<T extends Number> extends AbstractSampledStatistic<T>
   public List<Timestamped<T>> history() {
     latency.touch();
     return super.history();
+  }
+
+  @Override
+  public List<Timestamped<T>> history(long since) {
+    latency.touch();
+    return super.history(since);
   }
 }

--- a/src/main/java/org/terracotta/statistics/extended/SemiExpiringSampledStatistic.java
+++ b/src/main/java/org/terracotta/statistics/extended/SemiExpiringSampledStatistic.java
@@ -53,14 +53,20 @@ public class SemiExpiringSampledStatistic<T extends Number> extends AbstractSamp
    * @param historyTime     period between samples
    * @param historyTimeUnit unit of period between samples
    */
-  public SemiExpiringSampledStatistic(ValueStatistic<T> source, ScheduledExecutorService executor, int historySize, long historyTime, TimeUnit historyTimeUnit) {
-    super(source, executor, historySize, historyTime, historyTimeUnit);
+  public SemiExpiringSampledStatistic(ValueStatistic<T> source, ScheduledExecutorService executor, int historySize, long historyTime, TimeUnit historyTimeUnit, SampleType type) {
+    super(source, executor, historySize, historyTime, historyTimeUnit, type);
   }
 
   @Override
   public List<Timestamped<T>> history() {
     touch();
     return super.history();
+  }
+
+  @Override
+  public List<Timestamped<T>> history(long since) {
+    touch();
+    return super.history(since);
   }
 
   @Override

--- a/src/main/java/org/terracotta/statistics/extended/StatisticHistory.java
+++ b/src/main/java/org/terracotta/statistics/extended/StatisticHistory.java
@@ -81,6 +81,15 @@ class StatisticHistory<T extends Number> {
   }
 
   /**
+   * History since given time in ms
+   *
+   * @return the list
+   */
+  public List<Timestamped<T>> history(long since) {
+    return history.getArchive(since);
+  }
+
+  /**
    * Adjust.
    *
    * @param historySize     the history size
@@ -91,4 +100,5 @@ class StatisticHistory<T extends Number> {
     history.setCapacity(historySize);
     sampler.setPeriod(historyPeriod, historyTimeUnit);
   }
+
 }

--- a/src/test/java/org/terracotta/statistics/StatisticMapperTest.java
+++ b/src/test/java/org/terracotta/statistics/StatisticMapperTest.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.statistics;
+
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.terracotta.statistics.observer.ChainedOperationObserver;
+
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.EnumSet.of;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.StringContains.containsString;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.terracotta.statistics.StatisticMapperTest.Source.C;
+import static org.terracotta.statistics.StatisticMapperTest.Source.D;
+import static org.terracotta.statistics.StatisticMapperTest.Source.E;
+import static org.terracotta.statistics.StatisticMapperTest.Target.A;
+import static org.terracotta.statistics.StatisticMapperTest.Target.B;
+
+public class StatisticMapperTest {
+
+  @Test
+  public void testInvalidSourceStatisticSet() {
+    try {
+      new StatisticMapper<Source, Target>(Collections.<Target, Set<Source>>singletonMap(A, of(C, D)), null);
+      fail("should throw");
+    } catch (IllegalArgumentException e) {
+      assertThat(e.getMessage(), containsString("target outcomes [B]"));
+    }
+  }
+
+  @Test
+  public void testInvalidTargetStatisticSet() {
+    try {
+      Map<Target, Set<Source>> translation = new EnumMap<Target, Set<Source>>(Target.class);
+      translation.put(A, of(C));
+      translation.put(B, of(D));
+      new StatisticMapper<Source, Target>(translation, null);
+      fail("should throw");
+    } catch (IllegalArgumentException e) {
+      assertThat(e.getMessage(), containsString("source outcomes [E]"));
+    }
+  }
+
+  @Test
+  public void testIllDefinedTranslation() {
+    try {
+      Map<Target, Set<Source>> translation = new EnumMap<Target, Set<Source>>(Target.class);
+      translation.put(A, of(C, D));
+      translation.put(B, of(D, E));
+      new StatisticMapper<Source, Target>(translation, null);
+      fail("should throw");
+    } catch (IllegalArgumentException e) {
+      assertThat(e.getMessage(), containsString("mapping is ill-defined"));
+    }
+  }
+
+  @Test
+  public void testTargetTypeExtraction() {
+    Map<Target, Set<Source>> translation = new EnumMap<Target, Set<Source>>(Target.class);
+    translation.put(A, of(C));
+    translation.put(B, of(D, E));
+    StatisticMapper<Source, Target> mapper = new StatisticMapper<Source, Target>(translation, null);
+
+    assertThat(mapper.type(), equalTo(Target.class));
+  }
+
+  @Test
+  public void testStatisticTranslation() {
+    OperationStatistic<Source> statistic = mock(OperationStatistic.class);
+    Map<Target, Set<Source>> translation = new EnumMap<Target, Set<Source>>(Target.class);
+    translation.put(A, of(C));
+    translation.put(B, of(D, E));
+    StatisticMapper<Source, Target  > mapper = new StatisticMapper<Source, Target>(translation, statistic);
+
+    mapper.statistic(B);
+    verify(statistic).statistic(of(D, E));
+
+    mapper.statistic(A);
+    verify(statistic).statistic(of(C));
+  }
+
+  @Test
+  public void testStatisticSetTranslation() {
+    OperationStatistic<Source> statistic = mock(OperationStatistic.class);
+    Map<Target, Set<Source>> translation = new EnumMap<Target, Set<Source>>(Target.class);
+    translation.put(A, of(C));
+    translation.put(B, of(D, E));
+    StatisticMapper<Source, Target  > mapper = new StatisticMapper<Source, Target>(translation, statistic);
+
+    mapper.statistic(of(A, B));
+    verify(statistic).statistic(of(C, D, E));
+  }
+
+  @Test
+  public void testCountTranslation() {
+    OperationStatistic<Source> statistic = mock(OperationStatistic.class);
+    Map<Target, Set<Source>> translation = new EnumMap<Target, Set<Source>>(Target.class);
+    translation.put(A, of(C));
+    translation.put(B, of(D, E));
+    StatisticMapper<Source, Target  > mapper = new StatisticMapper<Source, Target>(translation, statistic);
+
+    mapper.count(B);
+    verify(statistic).sum(of(D, E));
+
+    mapper.count(A);
+    verify(statistic).sum(of(C));
+  }
+
+  @Test
+  public void testSumTranslation() {
+    OperationStatistic<Source> statistic = mock(OperationStatistic.class);
+    Map<Target, Set<Source>> translation = new EnumMap<Target, Set<Source>>(Target.class);
+    translation.put(A, of(C));
+    translation.put(B, of(D, E));
+    StatisticMapper<Source, Target  > mapper = new StatisticMapper<Source, Target>(translation, statistic);
+
+    mapper.sum(of(A, B));
+    verify(statistic).sum(of(C, D, E));
+  }
+
+  @Test
+  public void testFullSum() {
+    OperationStatistic<Source> statistic = mock(OperationStatistic.class);
+    Map<Target, Set<Source>> translation = new EnumMap<Target, Set<Source>>(Target.class);
+    translation.put(A, of(C));
+    translation.put(B, of(D, E));
+    StatisticMapper<Source, Target  > mapper = new StatisticMapper<Source, Target>(translation, statistic);
+
+    mapper.sum();
+
+    verify(statistic).sum();
+  }
+
+  @Test
+  public void testDerivedStatisticBeginDelegation() {
+    ArgumentCaptor<ChainedOperationObserver> wrapperCapture = ArgumentCaptor.forClass(ChainedOperationObserver.class);
+
+    OperationStatistic<Source> statistic = mock(OperationStatistic.class);
+    doNothing().when(statistic).addDerivedStatistic(wrapperCapture.capture());
+
+    Map<Target, Set<Source>> translation = new EnumMap<Target, Set<Source>>(Target.class);
+    translation.put(A, of(C));
+    translation.put(B, of(D, E));
+    StatisticMapper<Source, Target  > mapper = new StatisticMapper<Source, Target>(translation, statistic);
+
+    ChainedOperationObserver<? super Target> derived = mock(ChainedOperationObserver.class);
+
+    mapper.addDerivedStatistic(derived);
+
+    ChainedOperationObserver<Source> wrapper = wrapperCapture.getValue();
+
+    wrapper.begin(42L);
+    verify(derived).begin(42L);
+  }
+
+  @Test
+  public void testDerivedStatisticEndDelegation() {
+    ArgumentCaptor<ChainedOperationObserver> wrapperCapture = ArgumentCaptor.forClass(ChainedOperationObserver.class);
+
+    OperationStatistic<Source> statistic = mock(OperationStatistic.class);
+    doNothing().when(statistic).addDerivedStatistic(wrapperCapture.capture());
+
+    Map<Target, Set<Source>> translation = new EnumMap<Target, Set<Source>>(Target.class);
+    translation.put(A, of(C));
+    translation.put(B, of(D, E));
+    StatisticMapper<Source, Target  > mapper = new StatisticMapper<Source, Target>(translation, statistic);
+
+    ChainedOperationObserver<? super Target> derived = mock(ChainedOperationObserver.class);
+
+    mapper.addDerivedStatistic(derived);
+
+    ChainedOperationObserver<Source> wrapper = wrapperCapture.getValue();
+
+    wrapper.end(43L, E);
+    verify(derived).end(43L, B);
+
+    wrapper.end(44L, C);
+    verify(derived).end(44L, A);
+
+    wrapper.end(45L, D);
+    verify(derived).end(45L, B);
+  }
+
+  @Test
+  public void testDerivedStatisticEndWithParametersDelegation() {
+    ArgumentCaptor<ChainedOperationObserver> wrapperCapture = ArgumentCaptor.forClass(ChainedOperationObserver.class);
+
+    OperationStatistic<Source> statistic = mock(OperationStatistic.class);
+    doNothing().when(statistic).addDerivedStatistic(wrapperCapture.capture());
+
+    Map<Target, Set<Source>> translation = new EnumMap<Target, Set<Source>>(Target.class);
+    translation.put(A, of(C));
+    translation.put(B, of(D, E));
+    StatisticMapper<Source, Target  > mapper = new StatisticMapper<Source, Target>(translation, statistic);
+
+    ChainedOperationObserver<? super Target> derived = mock(ChainedOperationObserver.class);
+
+    mapper.addDerivedStatistic(derived);
+
+    ChainedOperationObserver<Source> wrapper = wrapperCapture.getValue();
+
+    wrapper.end(43L, E, 1L, 2L);
+    verify(derived).end(43L, B, 1L, 2L);
+
+    wrapper.end(44L, C, 2L, 1L);
+    verify(derived).end(44L, A, 2L, 1L);
+
+    wrapper.end(45L, D, 3L, 4L);
+    verify(derived).end(45L, B, 3L, 4L);
+  }
+
+  @Test
+  public void testDerivedStatisticRemovalDelegation() {
+    OperationStatistic<Source> statistic = mock(OperationStatistic.class);
+
+    Map<Target, Set<Source>> translation = new EnumMap<Target, Set<Source>>(Target.class);
+    translation.put(A, of(C));
+    translation.put(B, of(D, E));
+    StatisticMapper<Source, Target  > mapper = new StatisticMapper<Source, Target>(translation, statistic);
+
+    ChainedOperationObserver<? super Target> derived = mock(ChainedOperationObserver.class);
+
+    mapper.addDerivedStatistic(derived);
+    mapper.removeDerivedStatistic(derived);
+
+    verify(statistic).removeDerivedStatistic(any(ChainedOperationObserver.class));
+  }
+
+  enum Target {
+    A, B
+  }
+
+  enum Source {
+    C, D, E
+  }
+}


### PR DESCRIPTION
➕ Close #16 - Stat framework improvements and fixes

- ➕ StatisticManager.getSampledStatistic()
- ➕ StatisticManager.getSampledCompoundStatistic()
- ➕ SampledStatistic.history(since)
- ➕ SampledStatistic.type()
- ➕ RegisteredStatistic.getType()
- ➕ RegisteredCompoundStatistic.getResult()
- ➕ RegisteredRatioStatistic.getSampledStatistic()
- 🐛 Fix generic signatures in methods
- 🎨 Moved the stat mapper classes from Ehcache

This is for ehcache/ehcache3#1579 : to cleanup some duplicated code