### PR TITLE
Clean the PassThrough binding when cleaning a node (close #13)

### DIFF
--- a/src/main/java/org/terracotta/context/ContextAwareTreeNode.java
+++ b/src/main/java/org/terracotta/context/ContextAwareTreeNode.java
@@ -1,0 +1,72 @@
+/*
+ * All content copyright Terracotta, Inc., unless otherwise indicated.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.context;
+
+import org.terracotta.statistics.StatisticsManager;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Node used to wrap real tree node to keep the context object. Only used
+ * by {@link ContextManager#nodeFor(Object)} to allow the fluent interface
+ * to forward the context to {@link TreeNode} methods.
+ * <p>
+ * Currently, the only method using it is {@link ContextAwareTreeNode#clean()}
+ * that will make sure the context is removed from the {@link org.terracotta.statistics.PassThroughStatistic}
+ */
+class ContextAwareTreeNode implements TreeNode {
+
+  private Object context;
+  private TreeNode wrappedNode;
+
+  public ContextAwareTreeNode(TreeNode node, Object context) {
+    this.context = context;
+    this.wrappedNode = node;
+  }
+
+  @Override
+  public Set<? extends TreeNode> getChildren() {
+    return wrappedNode.getChildren();
+  }
+
+  @Override
+  public List<? extends TreeNode> getPath() throws IllegalStateException {
+    return wrappedNode.getPath();
+  }
+
+  @Override
+  public Collection<List<? extends TreeNode>> getPaths() {
+    return wrappedNode.getPaths();
+  }
+
+  @Override
+  public ContextElement getContext() {
+    return wrappedNode.getContext();
+  }
+
+  @Override
+  public String toTreeString() {
+    return wrappedNode.toTreeString();
+  }
+
+  @Override
+  public void clean() {
+    wrappedNode.clean();
+    StatisticsManager.removePassThroughStatistics(context);
+  }
+}

--- a/src/main/java/org/terracotta/context/ContextManager.java
+++ b/src/main/java/org/terracotta/context/ContextManager.java
@@ -16,7 +16,6 @@
 package org.terracotta.context;
 
 import java.lang.reflect.Field;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
@@ -99,7 +98,8 @@ public class ContextManager {
    * @return {@code TreeNode} associated with this object
    */
   public static TreeNode nodeFor(Object object) {
-    return getTreeNode(object);
+    TreeNode node = getTreeNode(object);
+    return node == null ? null : new ContextAwareTreeNode(node, object);
   }
 
   public static void registerContextCreationListener(ContextCreationListener listener) {

--- a/src/main/java/org/terracotta/context/WeakIdentityHashMap.java
+++ b/src/main/java/org/terracotta/context/WeakIdentityHashMap.java
@@ -40,6 +40,12 @@ public class WeakIdentityHashMap<K, V> {
     return backing.putIfAbsent(createReference(key, referenceQueue), value);
   }
 
+  public V remove(K key) {
+    V v = backing.remove(createReference(key, null));
+    clean();
+    return v;
+  }
+
   private void clean() {
     Reference<? extends K> ref;
     while ((ref = referenceQueue.poll()) != null) {

--- a/src/main/java/org/terracotta/statistics/PassThroughStatistic.java
+++ b/src/main/java/org/terracotta/statistics/PassThroughStatistic.java
@@ -43,7 +43,15 @@ class PassThroughStatistic<T extends Number> implements ValueStatistic<T> {
     }
     collection.add(stat);
   }
-  
+
+  public static void removeStatistics(Object to) {
+    BINDING.remove(to);
+  }
+
+  static boolean hasStatisticsFor(Object to) {
+    return BINDING.get(to) != null;
+  }
+
   @ContextAttribute("name") public final String name;
   @ContextAttribute("tags") public final Set<String> tags;
   @ContextAttribute("properties") public final Map<String, Object> properties;

--- a/src/main/java/org/terracotta/statistics/StatisticsManager.java
+++ b/src/main/java/org/terracotta/statistics/StatisticsManager.java
@@ -80,6 +80,10 @@ public class StatisticsManager extends ContextManager {
     associate(context).withChild(stat);
   }
 
+  public static void removePassThroughStatistics(Object context) {
+    PassThroughStatistic.removeStatistics(context);
+  }
+  
   private static void parseStatisticAnnotations(final Object object) {
     for (final Method m : object.getClass().getMethods()) {
       Statistic anno = m.getAnnotation(Statistic.class);
@@ -97,7 +101,7 @@ public class StatisticsManager extends ContextManager {
       } 
     }
   }
-  
+
   static class MethodCallable<T> implements Callable<T> {
 
     private final WeakReference<Object> targetRef;

--- a/src/test/java/org/terracotta/context/ContextManagerTest.java
+++ b/src/test/java/org/terracotta/context/ContextManagerTest.java
@@ -1,0 +1,29 @@
+/*
+ * All content copyright Terracotta, Inc., unless otherwise indicated.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.context;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.*;
+
+public class ContextManagerTest {
+
+  @Test
+  public void nodeForUnknownContext() throws Exception {
+    assertThat(ContextManager.nodeFor(this), nullValue());
+  }
+}

--- a/src/test/java/org/terracotta/context/WeakIdentityHashMapTest.java
+++ b/src/test/java/org/terracotta/context/WeakIdentityHashMapTest.java
@@ -33,20 +33,8 @@ public class WeakIdentityHashMapTest {
   
   @Test
   public void testEnqueuedReferenceIsRemoved() {
-    
-    final Queue<Reference<String>> references = new LinkedList<Reference<String>>();
-    WeakIdentityHashMap<String, String> map = new WeakIdentityHashMap<String, String>() {
-      @Override
-      protected Reference<String> createReference(String key, ReferenceQueue<? super String> queue) {
-        if (queue == null) {
-          return super.createReference(key, queue);
-        } else {
-          Reference<String> ref = super.createReference(key, queue);
-          references.add(ref);
-          return ref;
-        }
-      }
-    };
+    Queue<Reference<String>> references = new LinkedList<Reference<String>>();
+    WeakIdentityHashMap<String, String> map = createRefTrackingWeakIdentityHashMap(references);
     
     assertThat(map.putIfAbsent("test", "test"), nullValue());
     assertThat(map.get("test"), is("test"));
@@ -58,8 +46,21 @@ public class WeakIdentityHashMapTest {
 
   @Test
   public void testEnqueuedCleanableReferenceIsRemovedAndCleaned() {
-    final Queue<Reference<String>> references = new LinkedList<Reference<String>>();
-    WeakIdentityHashMap<String, DummyCleanable> map = new WeakIdentityHashMap<String, DummyCleanable>() {
+    Queue<Reference<String>> references = new LinkedList<Reference<String>>();
+    WeakIdentityHashMap<String, DummyCleanable> map = createRefTrackingWeakIdentityHashMap(references);
+    
+    DummyCleanable value = new DummyCleanable();
+    assertThat(map.putIfAbsent("test", value), nullValue());
+    assertThat(map.get("test"), is(value));
+    
+    references.remove().enqueue();
+    
+    assertThat(map.get("test"), nullValue());
+    assertThat(value.isClean(), is(true));
+  }
+
+  private <T> WeakIdentityHashMap<String, T> createRefTrackingWeakIdentityHashMap(final Queue<Reference<String>> references) {
+    return new WeakIdentityHashMap<String, T>() {
       @Override
       protected Reference<String> createReference(String key, ReferenceQueue<? super String> queue) {
         if (queue == null) {
@@ -71,17 +72,8 @@ public class WeakIdentityHashMapTest {
         }
       }
     };
-    
-    DummyCleanable value = new DummyCleanable();
-    assertThat(map.putIfAbsent("test", value), nullValue());
-    assertThat(map.get("test"), is(value));
-    
-    references.remove().enqueue();
-    
-    assertThat(map.get("test"), nullValue());
-    assertThat(value.isClean(), is(true));
   }
-  
+
   static class DummyCleanable implements WeakIdentityHashMap.Cleanable {
 
     private boolean cleaned = false;

--- a/src/test/java/org/terracotta/context/WeakIdentityHashMapTest.java
+++ b/src/test/java/org/terracotta/context/WeakIdentityHashMapTest.java
@@ -59,6 +59,17 @@ public class WeakIdentityHashMapTest {
     assertThat(value.isClean(), is(true));
   }
 
+  @Test
+  public void testRemoveActiveRef() {
+    Queue<Reference<String>> references = new LinkedList<Reference<String>>();
+    WeakIdentityHashMap<String, String> map = createRefTrackingWeakIdentityHashMap(references);
+
+    map.putIfAbsent("key", "value");
+
+    assertThat(map.remove("key"), is("value"));
+    assertThat(map.get("key"), nullValue());
+  }
+
   private <T> WeakIdentityHashMap<String, T> createRefTrackingWeakIdentityHashMap(final Queue<Reference<String>> references) {
     return new WeakIdentityHashMap<String, T>() {
       @Override


### PR DESCRIPTION
This is a different way to solve the `PassThrough` cleaning problem. It is entirely transparent to the client.