### PR TITLE
Fixes #53 : Explain the incorrectness in the histograms bar splitting and update testing accordingly:

### DIFF
--- a/src/main/java/org/terracotta/statistics/derived/histogram/BarSplittingBiasedHistogram.java
+++ b/src/main/java/org/terracotta/statistics/derived/histogram/BarSplittingBiasedHistogram.java
@@ -371,6 +371,74 @@ public class BarSplittingBiasedHistogram implements Histogram {
       return "[" + minimum + " --" + count() + "-> " + maximum + "]";
     }
 
+    /*
+     * This method is problematic.  What it's doing is attempting to split this bar in to two pieces, such that their
+     * counts are in the ratio ρ (the bar adjusted φ).
+     *  ______
+     * |      |
+     * |      |
+     * |      |
+     * |      |     ______     ______
+     * |      |    |      |   |      |
+     * | this | => |  s1  | + |  s2  |
+     * |______|    |______|   |______|
+     *
+     * So:
+     *   s2.count() = s1.count() * ρ
+     *   s1.count() + s2.count() = this.count()
+     *
+     *   s2.count() = (ρ / (1 + ρ)) * this.count()
+     *
+     * Define:
+     *   θ = (ρ / (1 + ρ))
+     *
+     * So we split off θ of the total count to form s2.  We then have to decide the bounds for s1 and s2...
+     * this is where things go wrong.
+     *
+     *     _______________
+     *    |         |     |
+     *    |         |   __|
+     *    |   ____  |  /  |
+     *    |  /    \_|_/   |
+     *    | /       |     |
+     *    |/      θ-qtle  |
+     *    |_________|_____|
+     *   min      split  max
+     *
+     * The 'correct' place to split the bar is at the θ-quantile of the distribution within the bar.  We don't know this
+     * however.  In fact we know nothing (Jon Snow) - instead we approximate the distribution as flat within the bar,
+     * so:
+     *     __________ __________
+     *    |          |          |
+     *    |    s1    |    s2    |
+     *    |__________|__________|
+     *   min  min+θ*(max-min)  max
+     *
+     * This inaccurate splitting corrupts our quantile measurements. What follows is a pseudo-mathematical justification
+     * for why this is okay.
+     *
+     * We define three regions of interest:
+     *
+     * θ-qtle = min + θ*(max-min); perfect split, uninteresting.
+     *
+     * θ-qtle > min + θ*(max-min); in this region:
+     *  * any quantile determined to fall within the bounds of s1 has it's upper boundary under-estimated. A major issue,
+     *    since this makes the upper bound look lower (read better) for a latency measure, while lying to our user.
+     *  * any quantile determined to fall within the bounds of s2 has it's lower boundary under-estimated. A non-issue,
+     *    this increases our uncertainty, but correctness is maintained.
+     *
+     * θ-qtle < min + θ*(max-min); in this region:
+     *  * any quantile determined to fall within the bounds of s1 has it's upper boundary over-estimated. A non-issue,
+     *    this increases our uncertainty, but correctness is maintained.
+     *  * any quantile determined to fall within the bounds of s2 has it's lower boundary over-estimated. A minor issue,
+     *    since for our purposes an excessive latency measure is to our detriment, but not that of our users.
+     *
+     * Finally, here comes the wooo... in the tail (where the high-percentiles exist) regions where
+     * θ-qtle > min + θ*(max-min) are rare since these are associated with regions of net +ve slope, and yet tails must
+     * have net -ve slope.
+     *
+     * I therefore declare everything safe, and sweep all this nonsense under the rug.
+     */
     Bar split(double ratio) {
       ExponentialHistogram split = eh.split(ratio);
       double upperMinimum = minimum + ((maximum - minimum) * ratio);

--- a/src/test/java/org/terracotta/statistics/derived/histogram/BarSplittingBiasedHistogramPreciseTest.java
+++ b/src/test/java/org/terracotta/statistics/derived/histogram/BarSplittingBiasedHistogramPreciseTest.java
@@ -15,65 +15,75 @@
  */
 package org.terracotta.statistics.derived.histogram;
 
-import org.junit.Rule;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+import org.hamcrest.core.DescribedAs;
 import org.junit.Test;
-import org.junit.rules.ErrorCollector;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Random;
+import java.util.function.Function;
 import java.util.stream.DoubleStream;
 
 import static java.lang.Math.ceil;
+import static java.util.Arrays.asList;
+import static java.util.Arrays.sort;
+import static java.util.Arrays.stream;
+import static java.util.stream.DoubleStream.concat;
 import static java.util.stream.DoubleStream.generate;
+import static org.hamcrest.collection.IsArrayContainingInOrder.arrayContaining;
 import static org.hamcrest.number.OrderingComparison.greaterThan;
 import static org.hamcrest.number.OrderingComparison.lessThanOrEqualTo;
+import static org.junit.Assert.assertThat;
 
 @RunWith(Parameterized.class)
 public class BarSplittingBiasedHistogramPreciseTest {
 
-  @Rule
-  public final ErrorCollector errors = new ErrorCollector();
-
   private static final double ERROR_THRESHOLD = 10;
 
+  private static final double[] HIGH_QUANTILES = new double[] {0.5, 0.75, 0.9, 0.99};
+  private static final double[] LOW_QUANTILES = stream(HIGH_QUANTILES).map(d -> 1 - d).toArray();
+  private static final double[] ALL_QUANTILES = concat(stream(LOW_QUANTILES), stream(HIGH_QUANTILES)).distinct().toArray();
   private final long seed;
   private final float bias;
   private final int bars;
+  private final double[] quantiles;
 
   @Parameterized.Parameters(name = "{index}: seed={0} bias={1}, bars={2}")
   public static Iterable<Object[]> data() {
     Random rndm = new Random();
     // seed, bias, bars
-    return Arrays.asList(new Object[][] {
-        {rndm.nextLong(), 0.01f, 20},
-        {rndm.nextLong(), 0.01f, 100},
-        {rndm.nextLong(), 0.01f, 1000},
+    return asList(new Object[][] {
+        {rndm.nextLong(), 0.01f, 20, HIGH_QUANTILES},
+        {rndm.nextLong(), 0.01f, 100, HIGH_QUANTILES},
+        {rndm.nextLong(), 0.01f, 1000, HIGH_QUANTILES},
 
-        {rndm.nextLong(), 0.1f, 20},
-        {rndm.nextLong(), 0.1f, 100},
-        {rndm.nextLong(), 0.1f, 1000},
+        {rndm.nextLong(), 0.1f, 20, HIGH_QUANTILES},
+        {rndm.nextLong(), 0.1f, 100, HIGH_QUANTILES},
+        {rndm.nextLong(), 0.1f, 1000, HIGH_QUANTILES},
 
-        {rndm.nextLong(), 1f, 20},
-        {rndm.nextLong(), 1f, 100},
-        {rndm.nextLong(), 1f, 1000},
+        {rndm.nextLong(), 1f, 20, ALL_QUANTILES},
+        {rndm.nextLong(), 1f, 100, ALL_QUANTILES},
+        {rndm.nextLong(), 1f, 1000, ALL_QUANTILES},
 
-        {rndm.nextLong(), 10f, 20},
-        {rndm.nextLong(), 10f, 100},
-        {rndm.nextLong(), 10f, 1000},
+        {rndm.nextLong(), 10f, 20, LOW_QUANTILES},
+        {rndm.nextLong(), 10f, 100, LOW_QUANTILES},
+        {rndm.nextLong(), 10f, 1000, LOW_QUANTILES},
 
-        {rndm.nextLong(), 100f, 20},
-        {rndm.nextLong(), 100f, 100},
-        {rndm.nextLong(), 100f, 1000},
+        {rndm.nextLong(), 100f, 20, LOW_QUANTILES},
+        {rndm.nextLong(), 100f, 100, LOW_QUANTILES},
+        {rndm.nextLong(), 100f, 1000, LOW_QUANTILES},
     });
   }
 
-  public BarSplittingBiasedHistogramPreciseTest(long seed, float biasRange, int bars) {
+  public BarSplittingBiasedHistogramPreciseTest(long seed, float biasRange, int bars, double[] quantiles) {
     this.bias = (float) Math.pow(biasRange, 1.0 / bars);
     this.bars = bars;
     this.seed = seed;
+    this.quantiles = quantiles;
   }
 
   @Test
@@ -82,7 +92,9 @@ public class BarSplittingBiasedHistogramPreciseTest {
 
     BarSplittingBiasedHistogram bsbh = new BarSplittingBiasedHistogram(bias, bars, Long.MAX_VALUE);
 
-    checkPercentiles(generate(() -> rndm.nextDouble() * 1000).limit(100000), bsbh, 0.01, 0.1, 0.25, 0.5, 0.75, 0.9, 0.99);
+    double slope = (rndm.nextDouble() * 999.99) + 0.01;
+    double offset = (rndm.nextDouble() - 0.5) * 1000;
+    checkPercentiles(generate(rndm::nextDouble).map(x -> (x * slope) + offset).limit(100000), bsbh, quantiles);
   }
 
   @Test
@@ -91,30 +103,54 @@ public class BarSplittingBiasedHistogramPreciseTest {
 
     BarSplittingBiasedHistogram bsbh = new BarSplittingBiasedHistogram(bias, bars, Long.MAX_VALUE);
 
-    checkPercentiles(generate(rndm::nextGaussian).limit(100000), bsbh, 0.01, 0.1, 0.25, 0.5, 0.75, 0.9, 0.99);
+    double width = (rndm.nextDouble() * 999.99) + 0.01;
+    double centroid = (rndm.nextDouble() - 0.5) * 1000;
+
+    checkPercentiles(generate(rndm::nextGaussian).map(x -> (x * width) + centroid).limit(100000), bsbh, quantiles);
   }
 
   private void checkPercentiles(DoubleStream data, BarSplittingBiasedHistogram histogram, double ... quantiles) {
     double[] values = data.toArray();
-    for (double d : values) {
-      histogram.event(d, 0);
-    }
 
-    Arrays.sort(values);
+    for (int i = 0; i < values.length; ) {
+      for (int j = 0; j < 1000 && i < values.length; i++) {
+        histogram.event(values[i], 0);
+      }
 
-    for (double q : quantiles) {
-      double[] bounds = histogram.getQuantileBounds(q);
+      sort(values, 0, i);
 
-      double ip = (values.length * q) - 1;
-      double ceil = ceil(ip);
-      if (ip == ceil) {
-        errors.checkThat("Quantile " + q + " lower bound:", bounds[0], lessThanOrEqualTo(values[(int) ip]));
-        errors.checkThat("Quantile " + q + " upper bound:", bounds[1], greaterThan(values[(int) (ip + 1)]));
-      } else {
-        errors.checkThat("Quantile " + q + " lower bound:", bounds[0], lessThanOrEqualTo(values[(int) ceil]));
-        errors.checkThat("Quantile " + q + " upper bound:", bounds[1], greaterThan(values[(int) ceil]));
+      for (double q : quantiles) {
+        double[] bounds = histogram.getQuantileBounds(q);
+
+        double ip = (i * q) - 1;
+        double ceil = ceil(ip);
+        if (ip == ceil) {
+          double lower = values[(int) ip];
+          double upper = values[(int) (ip + 1)];
+          assertThat("Quantile " + q + " after " + i, bounds, encompasses(lower, upper));
+        } else {
+          double value = values[(int) ceil];
+          assertThat("Quantile " + q + " after " + i, bounds, encompasses(value, value));
+        }
       }
     }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Matcher<double[]> encompasses(double lower, double upper) {
+    return new DescribedAs<double[]>("a range fully encompassing [%0, %1]",
+        convertedFrom(double[].class, a -> stream(a).boxed().toArray(Double[]::new),
+            arrayContaining(lessThanOrEqualTo(lower), greaterThan(upper))),
+        new Object[] {lower, upper}) {
+      @Override
+      public void describeMismatch(Object item, Description description) {
+        if (item instanceof double[] && ((double[]) item).length == 2) {
+          double[] array = (double[]) item;
+          description.appendText("in range [").appendValue(array[0]).appendText(", ").appendValue(array[1]).appendText(") ");
+        }
+        super.describeMismatch(item, description);
+      }
+    };
   }
 
   @Test
@@ -132,5 +168,24 @@ public class BarSplittingBiasedHistogramPreciseTest {
         bsbh.event(datum, time++);
       }
     }
+  }
+
+  private static <T, U> Matcher<T> convertedFrom(Class<T> type, Function<T, U> mapper, Matcher<U> matcher) {
+    return new TypeSafeMatcher<T>(type) {
+      @Override
+      public void describeTo(Description description) {
+        matcher.describeTo(description);
+      }
+
+      @Override
+      protected void describeMismatchSafely(T item, Description mismatchDescription) {
+        matcher.describeMismatch(mapper.apply(item), mismatchDescription);
+      }
+
+      @Override
+      protected boolean matchesSafely(T item) {
+        return matcher.matches(mapper.apply(item));
+      }
+    };
   }
 }


### PR DESCRIPTION
 * Testing *should not* ask for low biased quantiles from high-biased histograms and vice-versa.
 * Testing *should* be more thorough when checking with appropriate quantiles.
 * Splitting isn't perfect we should document why, and why we believe it's wrong in an 'okay' way.