### PR TITLE
Use version range for logging components

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,8 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <terracotta-os-snapshots-url>http://nexus.terracotta.eur.ad.sag/content/repositories/terracotta-os-snapshots</terracotta-os-snapshots-url>
     <terracotta-os-releases-url>http://nexus.terracotta.eur.ad.sag/content/repositories/terracotta-os-releases</terracotta-os-releases-url>
-    <slf4j.version>1.7.32</slf4j.version>
+    <slf4j.base.version>1.7.32</slf4j.base.version>
+    <slf4j.range.version>[${slf4j.base.version},1.7.9999)</slf4j.range.version>
     <spotbugs.version>3.1.6</spotbugs.version>
   </properties>
 
@@ -47,7 +48,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>${slf4j.version}</version>
+      <version>${slf4j.range.version}</version>
     </dependency>
 
     <dependency>
@@ -59,7 +60,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-jdk14</artifactId>
-      <version>${slf4j.version}</version>
+      <version>${slf4j.range.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
This commit shifts to the use of version ranges for SLF4J.  SLF4J is
capped at 1.7.9999 to avoid picking up 1.8.0-betaX releases which
will not work with released versions of Logback before 1.3.x.